### PR TITLE
Bump lets-talk-about to ^0.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "lets-talk-about": "^0.5.2"
+        "lets-talk-about": "^0.5.3"
       }
     },
     "../lets-talk-about": {
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
@@ -21,16 +21,16 @@
         "gray-matter": "^4.0.3",
         "highlight.js": "^11.11.1",
         "markdown-it": "^14.1.1",
-        "mermaid": "^11.14.0",
-        "vite": "^8.0.7"
+        "mermaid": "^11.15.0",
+        "vite": "^8.0.13"
       },
       "bin": {
         "lets-talk-about": "bin/cli.js"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.10",
-        "@types/node": "^25.5.2",
-        "typescript": "^6.0.2"
+        "@biomejs/biome": "^2.4.15",
+        "@types/node": "^25.9.0",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/lets-talk-about": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "deploy": "lets-talk-about deploy"
   },
   "dependencies": {
-    "lets-talk-about": "^0.5.2"
+    "lets-talk-about": "^0.5.3"
   }
 }


### PR DESCRIPTION
## Summary
Picks up the security patches released in [lets-talk-about@0.5.3](https://github.com/tamino-martinius/lets-talk-about/releases/tag/v0.5.3) — fixes moderate-severity Dependabot advisories in `mermaid`, `vite`/`postcss`, `dompurify`, and `uuid` transitively.

This is the only direct dependency in this repo, so no other bumps are needed.

## Test plan
- [x] `npm install` succeeds
- [x] `npm audit` → 0 vulnerabilities
- [ ] `npm run build` produces a working `dist/`